### PR TITLE
Fix for FreeBSD compatibility

### DIFF
--- a/Network/Socket/Activation.hs
+++ b/Network/Socket/Activation.hs
@@ -61,7 +61,7 @@ socketStatus fd = do
     listeningInt <- lift $ c_socket_listening fd
     case listeningInt of
       0 -> return Bound
-      1 -> return Listening
+      x | x > 0 -> return Listening
       _ -> mzero
 
 foreign import ccall unsafe "socket_family"


### PR DESCRIPTION
For some reason `getsockopt(...SO_ACCEPTCONN...)` returns `2` for a listening socket.

**UPD** here's why, answer from IRC:
> Freaky: myfreeweb: it's #defined as 2, and used in a bitmask, so presumably when you ask for that it just returns so_options & SO_ACCEPTCONN - which will be 2 if the flag is set and 0 otherwise